### PR TITLE
URL Cleanup

### DIFF
--- a/cockroachdb/full.sh
+++ b/cockroachdb/full.sh
@@ -1,5 +1,5 @@
 lein do clean, run test \
-  --tarball http://aphyr.com/media/cockroach-2017-03-30.tar.bz2 \
+  --tarball https://aphyr.com/media/cockroach-2017-03-30.tar.bz2 \
   --username admin \
   --nodes-file ~/nodes \
   --test sets \

--- a/rethinkdb/resources/setup.sh
+++ b/rethinkdb/resources/setup.sh
@@ -2,7 +2,7 @@
 # tc qdisc add dev eth0 root netem delay 100ms \
 #   || tc qdisc change dev eth0 root netem delay 100ms
 rm -rf /root/rethinkdb_data
-base=http://download.rethinkdb.com/apt/pool
+base=https://download.rethinkdb.com/apt/pool
 version=/precise/main/r/rethinkdb/rethinkdb_2.1.5~0precise_amd64.deb
 if [[ ! -f /root/rdb.deb ]]; then
   curl $base/$version > /root/rdb.deb


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://aphyr.com/media/cockroach-2017-03-30.tar.bz2 (301) migrated to:  
  https://aphyr.com/media/cockroach-2017-03-30.tar.bz2 ([https](https://aphyr.com/media/cockroach-2017-03-30.tar.bz2) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://download.rethinkdb.com/apt/pool migrated to:  
  https://download.rethinkdb.com/apt/pool ([https](https://download.rethinkdb.com/apt/pool) result 301).