### PR TITLE
Output rabbit_fifo_dlx_worker state

### DIFF
--- a/rabbitmq/src/main/clojure/jepsen/rabbitmq.clj
+++ b/rabbitmq/src/main/clojure/jepsen/rabbitmq.clj
@@ -113,7 +113,9 @@
                (let [ status (c/exec* "/tmp/rabbitmq-server/sbin/rabbitmqctl eval \"case whereis('%2F_jepsen.queue') of undefined -> no_local_member; _ -> sys:get_status(whereis('%2F_jepsen.queue')) end.\"")]
                                       (info "Quorum Member Status for 'jepsen.queue': " status))
                (let [ status (c/exec* "/tmp/rabbitmq-server/sbin/rabbitmqctl eval \"case whereis('%2F_jepsen.queue.dead.letter') of undefined -> no_local_member; _ -> sys:get_status(whereis('%2F_jepsen.queue.dead.letter')) end.\"")]
-                                      (info "Quorum Member Status for 'jepsen.queue.dead.letter': " status))))
+                                      (info "Quorum Member Status for 'jepsen.queue.dead.letter': " status))
+               (let [ status (c/exec* "/tmp/rabbitmq-server/sbin/rabbitmqctl eval \"case supervisor:which_children(rabbit_fifo_dlx_sup) of [] -> no_local_dlx_worker; [{undefined, Pid, worker, _}] -> sys:get_status(Pid) end.\"")]
+                                      (info "Status for rabbit_fifo_dlx_worker: " status))))
                ; there is no real need to clear anything down here as we
                ; reset everything before each run
                (info node "Teardown complete")))


### PR DESCRIPTION
Output rabbit_fifo_dlx_worker state at the end of a Jepsen test run in
addition to the state of source quorum queue and destination quorum
queue.

This makes is easier to analyse failed Jepsen tests when run with the
`--dead-letter true` flag.

In our Jepsen tests, we know that there is at most one
rabbit_fifo_dlx_worker process per node because we create a single
source quorum queue with at-least-once dead lettering enabled.

An example output looks like:
```
INFO [2022-08-10 15:20:16,346] jepsen node n3 - jepsen.rabbitmq Status for rabbit_fifo_dlx_worker:  no_local_dlx_worker
INFO [2022-08-10 15:20:16,348] jepsen node n4 - jepsen.rabbitmq Status for rabbit_fifo_dlx_worker:  no_local_dlx_worker
INFO [2022-08-10 15:20:16,348] jepsen node n5 - jepsen.rabbitmq Status for rabbit_fifo_dlx_worker:  no_local_dlx_worker
INFO [2022-08-10 15:20:16,446] jepsen node n1 - jepsen.rabbitmq Status for rabbit_fifo_dlx_worker:  {status,<11940.1629.0>,
 {module,gen_server},
 [[{guid,{{4036523199,3851121779,3279875378,3044861436},398}},
   {'$initial_call',{rabbit_fifo_dlx_worker,init,1}},
   {'$ancestors',[rabbit_fifo_dlx_sup,rabbit_sup,<11940.222.0>]}],
  running,<11940.582.0>,[],
  [{header,"Status for generic server <0.1629.0>"},
   {data,[{"Status",running},{"Parent",<11940.582.0>},{"Logged events",[]}]},
   {data,
    [{"State",
      #{dlx_client_state =>
         #{last_msg_id => 398,leader => {'%2F_jepsen.queue',rabbit@n1}},
        exchange_ref => {resource,<<"/">>,exchange,<<>>},
        logged => #{},next_out_seq => 400,pendings => #{},
        queue_ref => {resource,<<"/">>,queue,<<"jepsen.queue">>},
        queue_type_state =>
         {rabbit_queue_type,
          #{{resource,<<"/">>,queue,<<"jepsen.queue.dead.letter">>} =>
             {ctx,rabbit_quorum_queue,
              {resource,<<"/">>,queue,<<"jepsen.queue.dead.letter">>},
              {state,
               {cfg,
                {resource,<<"/">>,queue,<<"jepsen.queue.dead.letter">>},
                [{'%2F_jepsen.queue.dead.letter',rabbit@n2},
                 {'%2F_jepsen.queue.dead.letter',rabbit@n3},
                 {'%2F_jepsen.queue.dead.letter',rabbit@n4},
                 {'%2F_jepsen.queue.dead.letter',rabbit@n5},
                 {'%2F_jepsen.queue.dead.letter',rabbit@n1}],
                32,#Fun<rabbit_quorum_queue.0.20439808>,
                #Fun<rabbit_quorum_queue.1.20439808>,20000,0},
               {'%2F_jepsen.queue.dead.letter',rabbit@n5},
               go,399,400,false,#{},#{},#{},undefined}}},
          #{}},
        routing_key => <<"jepsen.queue.dead.letter">>,settle_timeout => 15000,
        settled_ids => [],timer_is_active => false}}]}]]}
INFO [2022-08-10 15:20:16,447] jepsen node n2 - jepsen.rabbitmq Status for rabbit_fifo_dlx_worker:  no_local_dlx_worker
INFO [2022-08-10 15:20:16,471] jepsen test runner - jepsen.core {:perf
 {:latency-graph {:valid? true},
  :rate-graph {:valid? true},
  :valid? true},
 :queue
 {:ok-count 592,
  :duplicated-count 0,
  :valid? true,
  :lost-count 0,
  :lost #{},
  :acknowledged-count 590,
  :recovered #{311 232},
  :attempt-count 597,
  :unexpected #{},
  :unexpected-count 0,
  :recovered-count 2,
  :duplicated #{}},
 :valid? true}


Everything looks good! ヽ(‘ー`)ノ
```